### PR TITLE
search also in /usr/share/unicode

### DIFF
--- a/unicode.go
+++ b/unicode.go
@@ -52,11 +52,13 @@ var (
 	unicodeDataTxt string
 	goroot         string
 	gopath         string
+	syspath        string
 )
 
 func init() {
 	goroot = os.Getenv("GOROOT")
 	gopath = os.Getenv("GOPATH")
+	syspath = "/usr/share/unicode"
 }
 
 func getUnicode() {
@@ -80,6 +82,11 @@ func getPath(base string) string {
 			return f
 		}
 	}
+	f := filepath.Join(syspath, base)
+	if _, err := os.Stat(f); err == nil {
+		return f
+	}
+
 	fmt.Fprintf(os.Stderr, "unicode: can't find %s\n", base)
 	os.Exit(1)
 	return ""


### PR DESCRIPTION
try to search for unicodeData.txt & unicode.txt in /usr/share/unicode if not found in $GOPATH/src/robpike.io/cmd/unicode

might be useful when golang is not installed on the system and `unicode` binary just copied over /usr/local/bin