### PR TITLE
Refine argsAreRegexps, and document -g.

### DIFF
--- a/unicode.go
+++ b/unicode.go
@@ -15,6 +15,11 @@ usage: unicode [-c] [-d] [-n] [-t]
 	-U: output full Unicode description
 
 Default behavior sniffs the arguments to select -c vs. -n.
+
+For -g, regexps are compared against a string composed of the
+fields "{Codepoint}\t{Name}[; {Unicode 1.0 Name}]" (square
+brackets denote an optional extension, delimited with ";", if the
+entry has an obsolete 1.0 name).
 */
 package main // import "robpike.io/cmd/unicode"
 


### PR DESCRIPTION
Addresses #7.

Looking at the help strings for -g I got the intent was to match just the names of a unicodeLine. argAreRegexps used to:
1. construct what I call the _search-string_ out of the textual codepoint, name, and optionally 1.0-name
2. try to match the whole search-string
3. get the rune back out of a matched search-string

Now, it:
1. constructs the search-string from just name and 1.0-name
2. tries the match
3. parses the rune directly if matched